### PR TITLE
feat(Role): validate arguments, support string argument on assignRole method

### DIFF
--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -26,7 +26,7 @@ module.exports = function (schema) {
    * Assign role to user
    * @param {String} name - role name | { name: String, permissions: [{ name: String}] }
    */
-  schema.methods.assignRole = async function (role) {
+  schema.methods.assignRole = function (role) {
     if ((typeof role === 'string' && !role) || (typeof role === 'object' && !role.name))
       throw new Error(`Role name is required`);
 
@@ -45,7 +45,7 @@ module.exports = function (schema) {
    * Revoke role from user
    * @param {String} name - role name
    */
-  schema.methods.revokeRole = async function (name) {
+  schema.methods.revokeRole = function (name) {
     if (typeof name !== 'string' || !name) throw new Error(`Role name is required`);
 
     if (this.role.name === name) {
@@ -68,6 +68,9 @@ module.exports = function (schema) {
   };
 
   schema.methods.givePermissionTo = function (payload) {
+    if (typeof payload !== 'string' || !payload) throw new Error(`Permission name is required`);
+
+    
     if (!this.permissions.some((permission) => permission.name === payload)) {
       this.permissions.push({ payload });
       this.save();
@@ -77,6 +80,8 @@ module.exports = function (schema) {
   };
 
   schema.methods.revokePermissionTo = function (name) {
+     if (typeof name !== 'string' || !name) throw new Error(`Permission name is required`);
+    
     this.permissions = this.permissions.filter((permission) => permission.name !== name);
 
     return this;

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -1,39 +1,69 @@
 /* eslint-disable func-names */
 /* eslint-disable no-param-reassign */
+/* eslint-disable import/no-unresolved */
+
+const { Schema } = require('mongoose');
 
 module.exports = function (schema) {
   schema.add({
     role: {
       name: String,
-      permissions: [{ name: String }],
+      permissions: [{ _id: { type: Schema.Types.ObjectId, default: undefined }, name: String }],
     },
-    permissions: [{ name: String }],
+    permissions: [{ _id: { type: Schema.Types.ObjectId, default: undefined }, name: String }],
   });
 
   schema.methods.can = function (name) {
+    if (!name) throw new Error(`Permission name is required`);
+
     return (
       this.role.permissions.some((permission) => permission.name === name) ||
       this.permissions.some((permission) => permission.name === name)
     );
   };
 
-  schema.methods.assignRole = function (role) {
-    this.role = role;
-    this.save();
+  /*
+   * Assign role to user
+   * @param {String} name - role name | { name: String, permissions: [{ name: String}] }
+   */
+  schema.methods.assignRole = async function (role) {
+    if ((typeof role === 'string' && !role) || (typeof role === 'object' && !role.name))
+      throw new Error(`Role name is required`);
 
-    return this;
+    if (role && role.name) {
+      this.role = role;
+    } else if (typeof role === 'string') {
+      this.role.name = role;
+    }
+
+    this.role = role;
+
+    return this.save();
   };
 
-  schema.methods.revokeRole = function (name) {
+  /*
+   * Revoke role from user
+   * @param {String} name - role name
+   */
+  schema.methods.revokeRole = async function (name) {
+    if (typeof name !== 'string' || !name) throw new Error(`Role name is required`);
+
     if (this.role.name === name) {
       this.role = {};
-      this.save();
+      return this.save();
     }
 
     return this;
   };
 
+  /*
+   * Check has an user has a role assigned to him/her
+   * @param {String} name - role name
+   */
+
   schema.methods.hasRole = function (name) {
+    if (typeof name !== 'string' || !name) throw new Error(`Role name is required`);
+
     return this.role.name === name;
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-permissions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Mongoose plugin for managing roles and permissions (rbac) in a simpler way.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
* [x] -   validate arguments on hasRole, assignRole, revokeRole methods
* [x] -   support string argument on assignRole & revokeRole method
* [x] -  validate permission related methods
* [x] -   make permissions un-necessary  key _id undefined. 


Solved Issue: [ Async methods and error handling #1 ](https://github.com/sayburgh-solutions/mongoose-permissions/issues/1)